### PR TITLE
fix: multiple imports on one line

### DIFF
--- a/test_files/multi_imports.expected.py
+++ b/test_files/multi_imports.expected.py
@@ -1,6 +1,12 @@
+import os
+import sys
+
 from . import bar, foo
 from . import cat, loop
 
 
 def go():
+    argv = sys.argv
+    path = os.getcwd()
+    print(argv, path)
     return foo() + bar() + cat() + loop()

--- a/test_files/multi_imports.py
+++ b/test_files/multi_imports.py
@@ -1,6 +1,10 @@
+import sys, os
 from . import cat, loop
 from . import foo, bar
 
 
 def go():
+    argv = sys.argv
+    path = os.getcwd()
+    print(argv, path)
     return foo() + bar() + cat() + loop()

--- a/zimports.py
+++ b/zimports.py
@@ -53,13 +53,18 @@ def _rewrite_source(options, filename, source_lines):
 
     # flatten imports into single import per line and rewrite
     # full source
-    if not options.multi_imports:
-        imports = list(
-            _dedupe_single_imports(
-                _as_single_imports(imports, stats, expand_stars=expand_stars),
-                stats,
+    expanded_imports = []
+    for import_node in imports:
+        if options.multi_imports and import_node.is_from:
+            expanded_imports.append(import_node)
+        else:
+            expanded_imports += list(
+                _dedupe_single_imports(
+                    _as_single_imports([import_node], stats, expand_stars=expand_stars),
+                    stats,
+                )
             )
-        )
+    imports[:] = expanded_imports
 
     on_source_lines = _write_source(
         source_lines, imports, [],


### PR DESCRIPTION
multiple imports on one line is not allowed by pep8 for no-from imports