### PR TITLE
Respect max-line-length option of flake8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,45 +82,51 @@ Usage
 
 The script can run without any configuration, options are as follows::
 
-  $ zimports --help
-  usage: zimports [-h] [-m APPLICATION_IMPORT_NAMES]
-                  [-p APPLICATION_PACKAGE_NAMES] [--style STYLE] [-k]
-                  [--heuristic-unused HEURISTIC_UNUSED] [--statsonly] [-e]
-                  [--diff] [--stdout]
-                  filename [filename ...]
+usage: zimports [-h] [-m APPLICATION_IMPORT_NAMES]
+                [-p APPLICATION_PACKAGE_NAMES] [--style STYLE]
+                [--multi-imports] [--max-line-length MAX_LINE_LENGTH] [-k]
+                [--heuristic-unused HEURISTIC_UNUSED] [--statsonly] [-e]
+                [--diff] [--stdout]
+                filename [filename ...]
 
-  positional arguments:
-    filename              Python filename(s) or directories
+positional arguments:
+  filename              Python filename(s) or directories
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    -m APPLICATION_IMPORT_NAMES, --application-import-names APPLICATION_IMPORT_NAMES
-                          comma separated list of names that should be
-                          considered local to the application. reads from
-                          [flake8] application-import-names by default.
-    -p APPLICATION_PACKAGE_NAMES, --application-package-names APPLICATION_PACKAGE_NAMES
-                          comma separated list of names that should be
-                          considered local to the organization. reads from
-                          [flake8] application-package-names by default.
-    --style STYLE         import order styling, reads from [flake8] import-
-                          order-style by default, or defaults to 'google'
-    --multi-imports       If set, multiple imports can exist on one line
-    -k, --keep-unused     keep unused imports even though detected as unused
-    --heuristic-unused HEURISTIC_UNUSED
-                          Remove unused imports only if number of imports is
-                          less than <HEURISTIC_UNUSED> percent of the total
-                          lines of code
-    --statsonly           don't write or display anything except the file stats
-    -e, --expand-stars    Expand star imports into the names in the actual
-                          module, which can then have unused names removed.
-                          Requires modules can be imported
-    --diff                don't modify files, just dump out diffs
-    --stdout              dump file output to stdout
+optional arguments:
+  -h, --help            show this help message and exit
+  -m APPLICATION_IMPORT_NAMES, --application-import-names APPLICATION_IMPORT_NAMES
+                        comma separated list of names that should be
+                        considered local to the application. reads from
+                        [flake8] application-import-names by default.
+  -p APPLICATION_PACKAGE_NAMES, --application-package-names APPLICATION_PACKAGE_NAMES
+                        comma separated list of names that should be
+                        considered local to the organization. reads from
+                        [flake8] application-package-names by default.
+  --style STYLE         import order styling, reads from [flake8] import-
+                        order-style by default, or defaults to 'google'
+  --multi-imports       If set, multiple imports can exist on one line
+  --max-line-length MAX_LINE_LENGTH
+                        The maximal number of characters per line of from-
+                        imports when using --multi-imports.
+  -k, --keep-unused     keep unused imports even though detected as unused
+  --heuristic-unused HEURISTIC_UNUSED
+                        Remove unused imports only if number of imports is
+                        less than <HEURISTIC_UNUSED> percent of the total
+                        lines of code
+  --statsonly           don't write or display anything except the file stats
+  -e, --expand-stars    Expand star imports into the names in the actual
+                        module, which can then have unused names removed.
+                        Requires modules can be imported
+  --diff                don't modify files, just dump out diffs
+  --stdout              dump file output to stdout
+
+
 
 Typically, configuration will be in ``setup.cfg`` for flake8 (support for
 tox.ini, pyproject.toml is TODO)::
 
     [flake8]
+    max-line-length=120
     enable-extensions = G
     ignore =
         A003,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     py_modules=('zimports', 'tests'),
     zip_safe=False,
     install_requires=['pyflakes', 'flake8-import-order'],
-    tests_require=['mock'],
+    tests_require=[],
     entry_points={
         'console_scripts': ['zimports = zimports:main'],
     }

--- a/test_files/multi_imports_long_lines.expected.py
+++ b/test_files/multi_imports_long_lines.expected.py
@@ -1,0 +1,26 @@
+# schema.py
+# Copyright (C) 2005-2017 the SQLAlchemy authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+"""Compatibility namespace for sqlalchemy.sql.schema and related.
+
+"""
+
+from .sql.base import SchemaVisitor
+from .sql.ddl import (
+    _CreateDropBase, _DDLCompiles, _DropView, AddConstraint, CreateColumn,
+    CreateIndex, CreateSchema, CreateSequence, CreateTable, DDL, DDLBase,
+    DDLElement, DropColumnComment, DropConstraint, DropIndex, DropSchema,
+    DropSequence, DropTable, DropTableComment, SetColumnComment,
+    SetTableComment, sort_tables, sort_tables_and_constraints)
+from .sql.naming import conv
+from .sql.schema import (
+    _get_table_key, BLANK_SCHEMA, CheckConstraint, Column,
+    ColumnCollectionConstraint, ColumnCollectionMixin, ColumnDefault,
+    Constraint, DefaultClause, DefaultGenerator, FetchedValue, ForeignKey,
+    ForeignKeyConstraint, Index, MetaData, PassiveDefault,
+    PrimaryKeyConstraint, SchemaItem, Sequence, Table, ThreadLocalMetaData,
+    UniqueConstraint)

--- a/test_files/multi_imports_long_lines.py
+++ b/test_files/multi_imports_long_lines.py
@@ -1,0 +1,70 @@
+# schema.py
+# Copyright (C) 2005-2017 the SQLAlchemy authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+"""Compatibility namespace for sqlalchemy.sql.schema and related.
+
+"""
+
+from .sql.base import (
+    SchemaVisitor
+    )
+
+
+from .sql.schema import (
+    BLANK_SCHEMA,
+    CheckConstraint,
+    Column,
+    ColumnDefault,
+    Constraint,
+    DefaultClause,
+    DefaultGenerator,
+    FetchedValue,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    MetaData,
+    PassiveDefault,
+    PrimaryKeyConstraint,
+    SchemaItem,
+    Sequence,
+    Table,
+    ThreadLocalMetaData,
+    UniqueConstraint,
+    _get_table_key,
+    ColumnCollectionConstraint,
+    ColumnCollectionMixin
+    )
+
+
+from .sql.naming import conv
+
+
+from .sql.ddl import (
+    DDL,
+    CreateTable,
+    DropTable,
+    CreateSequence,
+    DropSequence,
+    CreateIndex,
+    DropIndex,
+    CreateSchema,
+    DropSchema,
+    _DropView,
+    CreateColumn,
+    AddConstraint,
+    DropConstraint,
+    DDLBase,
+    DDLElement,
+    _CreateDropBase,
+    _DDLCompiles,
+    sort_tables,
+    sort_tables_and_constraints,
+    SetTableComment,
+    DropTableComment,
+    SetColumnComment,
+    DropColumnComment,
+)

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import contextlib
 import io
 import unittest
 
-import mock
+from unittest import mock
 import zimports
 
 
@@ -94,6 +94,10 @@ class ImportsTest(unittest.TestCase):
 
     def test_multiple_imports(self):
         self._assert_file("multi_imports.py", opts=("--multi-imports", ))
+
+    def test_multi_imports_long_lines(self):
+        self._assert_file("multi_imports_long_lines.py", opts=(
+            "--multi-imports", "--max-line-length=78", "-k"))
 
 
 sqlalchemy_names = [


### PR DESCRIPTION
When using --multi-imports, the import line will grow to arbitrary
lengths, even though this will fail the line length lint check.

This change adds a --max-line-length option to set the maximum line
length to use, using the value from the setup.cfg file as default.
This option is then used to break from-imports lines into multiple
lines if they are longer than the specified length.

For example, this line

    from zimports import ClassifiedImport, ImportVisitor, sort_imports, main

will, when run with --max-line-length=72 be transformed to

    from zimports import (
        ClassifiedImport, ImportVisitor, sort_imports, main)

The heavy lifting is done using the built-in textwrap module.

The tests did not pass when using the asname= keyword argument to
ast_cls, I'm assuming this is due to running on python 3.6.

I've also taken the liberty to use the built-in version of the mock
module, which has been there since python 3.3.