### PR TITLE
resolves #14

### DIFF
--- a/test_files/unicode_characters.expected.py
+++ b/test_files/unicode_characters.expected.py
@@ -1,0 +1,12 @@
+import bar
+import bat
+import foo
+
+
+class ImAUnicodeString:
+    my_char = u"姓名"
+    ustring = u'A unicode \u018e string \xf1'
+
+foo
+bar
+bat

--- a/test_files/unicode_characters.py
+++ b/test_files/unicode_characters.py
@@ -1,0 +1,12 @@
+import foo
+import bar
+import bat
+
+
+class ImAUnicodeString:
+    my_char = u"姓名"
+    ustring = u'A unicode \u018e string \xf1'
+    
+foo
+bar
+bat

--- a/tests.py
+++ b/tests.py
@@ -37,7 +37,7 @@ class ImportsTest(unittest.TestCase):
 
         if checkfile is None:
             checkfile = filename.replace(".py", ".expected.py")
-        with open("test_files/%s" % checkfile) as file_:
+        with open("test_files/%s" % checkfile, encoding="utf8") as file_:
             self.assertEqual(file_.read(), buf.getvalue())
 
     def setUp(self):
@@ -94,6 +94,9 @@ class ImportsTest(unittest.TestCase):
 
     def test_multiple_imports(self):
         self._assert_file("multi_imports.py", opts=("--multi-imports", ))
+
+    def test_unicode_characters(self):
+        self._assert_file("unicode_characters.py")
 
 
 sqlalchemy_names = [

--- a/zimports.py
+++ b/zimports.py
@@ -557,7 +557,7 @@ def _lines_with_newlines(lines):
 
 
 def _run_file(options, filename):
-    with open(filename) as file_:
+    with open(filename, encoding="utf8") as file_:
         source_lines = [line.rstrip() for line in file_]
     if options.keep_unused:
         if options.heuristic_unused:


### PR DESCRIPTION
On Windows OS, If a file contains unicode string(s), zimports would open that file using the systems locale encoder, for windows this is CP-1252, this will raise a UnicodeDecodeError. 

This proposed resolution will set the file encoding to utf-8 which allows the file containing unicode strings to be read in by zimports.