### PR TITLE
add direct support for black line length formatting

### DIFF
--- a/test_files/maintain_formatting.expected.py
+++ b/test_files/maintain_formatting.expected.py
@@ -1,0 +1,13 @@
+from .pool import (
+    FallbackAsyncAdaptedQueuePool as FallbackAsyncAdaptedQueuePool,
+)
+from .pool import QueuePool as QueuePool
+from .pool import SingletonThreadPool as SingletonThreadPool
+from .sql import (
+    LABEL_STYLE_TABLENAME_PLUS_COL as LABEL_STYLE_TABLENAME_PLUS_COL,
+)
+from .sql.expression import (
+    RollbackToSavepointClause as RollbackToSavepointClause,
+)
+from .types import VARBINARY as VARBINARY
+from .types import VARCHAR as VARCHAR

--- a/test_files/maintain_formatting.py
+++ b/test_files/maintain_formatting.py
@@ -1,0 +1,16 @@
+from .types import VARBINARY as VARBINARY
+from .types import VARCHAR as VARCHAR
+
+from .sql import (
+    LABEL_STYLE_TABLENAME_PLUS_COL as LABEL_STYLE_TABLENAME_PLUS_COL,
+)
+
+from .pool import (
+    FallbackAsyncAdaptedQueuePool as FallbackAsyncAdaptedQueuePool,
+    SingletonThreadPool as SingletonThreadPool,
+    QueuePool as QueuePool
+)
+
+from .sql.expression import (
+    RollbackToSavepointClause as RollbackToSavepointClause,
+)

--- a/test_files/maintain_formatting_multiline.expected.py
+++ b/test_files/maintain_formatting_multiline.expected.py
@@ -1,0 +1,13 @@
+from .pool import (
+    FallbackAsyncAdaptedQueuePool as FallbackAsyncAdaptedQueuePool,
+    QueuePool as QueuePool,
+    SingletonThreadPool as SingletonThreadPool,
+)
+from .sql import (
+    LABEL_STYLE_TABLENAME_PLUS_COL as LABEL_STYLE_TABLENAME_PLUS_COL,
+)
+from .sql.expression import (
+    RollbackToSavepointClause as RollbackToSavepointClause,
+)
+from .types import VARBINARY as VARBINARY
+from .types import VARCHAR as VARCHAR

--- a/tests.py
+++ b/tests.py
@@ -208,6 +208,18 @@ per-file-ignores =
     def test_issue_34(self):
         self._assert_file("issue_34.py")
 
+    def test_maintain_formatting(self):
+        self._assert_file(
+            "maintain_formatting.py", opts=["--black-line-length", "79"]
+        )
+
+    def test_maintain_formatting_multiline(self):
+        self._assert_file(
+            "maintain_formatting.py",
+            checkfile="maintain_formatting_multiline.expected.py",
+            opts=["--multi-imports", "--black-line-length", "79"],
+        )
+
 
 sqlalchemy_names = [
     "alias",

--- a/zimports/cli.py
+++ b/zimports/cli.py
@@ -47,6 +47,12 @@ def main(argv=None):
         "[flake8] import-order-style by default, or defaults to 'google'",
     )
     parser.add_argument(
+        "--black-line-length",
+        type=int,
+        help="Format long imports past given line length using Black-style "
+        "formatting"
+    )
+    parser.add_argument(
         "--multi-imports",
         action="store_true",
         help="If set, multiple imports can exist on one line",


### PR DESCRIPTION
There's no general way to determine from the source
how to format long lines.  instead, add --black-line-length
option where we will directly emulate black's formatting
style.

Fixes: #12