### PR TITLE
vendor lookup_entry_point to avoid pgk_resources deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     pyflakes
     flake8-import-order
     tomli
+    importlib-metadata;python_version<"3.10"
 
 [options.entry_points]
 console_scripts =

--- a/tests.py
+++ b/tests.py
@@ -22,6 +22,8 @@ class ImportsTest(unittest.TestCase):
                 return self.mock_sqlalchemy
             elif name == "sqlalchemy.orm":
                 return self.mock_sqlalchemy_orm
+            elif name == "zimports":
+                return __import__("zimports")
             else:
                 raise ImportError(name)
 
@@ -51,7 +53,6 @@ class ImportsTest(unittest.TestCase):
         encoding="utf-8",
         checkfile=None,
     ):
-
         with self._simulate_importlib(), self._capture_stdout() as buf:
             zimports.main(
                 ["test_files/%s" % filename]

--- a/zimports/vendored/flake8_import_order.py
+++ b/zimports/vendored/flake8_import_order.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+def lookup_entry_point(name):
+    try:
+        (ep,) = importlib_metadata.entry_points(
+            name=name, group="flake8_import_order.styles"
+        )
+        return ep
+    except ValueError:
+        raise LookupError("Unknown style {}".format(name))

--- a/zimports/zimports.py
+++ b/zimports/zimports.py
@@ -22,12 +22,12 @@ from typing import Set
 from typing import Tuple
 
 import flake8_import_order as f8io
-from flake8_import_order.styles import lookup_entry_point
 import pyflakes.checker
 import pyflakes.messages
 
 from .vendored.flake8 import matches_filename
 from .vendored.flake8 import normalize_path
+from .vendored.flake8_import_order import lookup_entry_point
 
 
 class RewritePass(enum.Enum):
@@ -673,7 +673,6 @@ def _remove_unused_names(
 def _dedupe_single_imports(
     import_nodes: Iterable[ClassifiedImport], stats: dict
 ):
-
     seen = {}
     orig_order: List[Tuple[ClassifiedImport, Any]] = []
 
@@ -713,7 +712,6 @@ def _as_single_imports(
     stats: dict,
     expand_stars: bool = False,
 ):
-
     for import_node in import_nodes:
         if not import_node.is_from:
             for ast_name in import_node.ast_names:
@@ -885,7 +883,6 @@ def _parse_magic_encoding_comment(fp):
 
 
 def _run_file(options, filename):
-
     lines, encoding_comment = _read_python_source(filename)
     source_lines = [line.rstrip() for line in lines]
 
@@ -922,7 +919,6 @@ def _run_file(options, filename):
         )
 
     if not options.statsonly:
-
         if options.diff:
             sys.stdout.writelines(
                 difflib.unified_diff(


### PR DESCRIPTION
fixes the error that happens when doing `python -Werror -c 'import zimport's`:
`DeprecationWarning: pkg_resources is deprecated as an API`
