### PR TITLE
add type ignore

### DIFF
--- a/test_files/nosort.expected.py
+++ b/test_files/nosort.expected.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 import typing
 from typing import Any
-from typing import Callable  # type: ignore # noqa F401
+from typing import Callable  # type: ignore
 from typing import Coroutine
 
 import greenlet  # type: ignore # noqa F401

--- a/test_files/nosort.py
+++ b/test_files/nosort.py
@@ -1,9 +1,9 @@
 import asyncio
 import sys
 import typing
-import greenlet  # type: ignore
+import greenlet  # type: ignore # noqa F401
 from typing import Any
-from typing import Callable  # type: ignore # noqa F401
+from typing import Callable  # type: ignore
 from typing import Coroutine
 
 from contextvars import copy_context as _copy_context  # noqa nosort

--- a/test_files/nosort.py
+++ b/test_files/nosort.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 import typing
-import greenlet  # type: ignore # noqa F401
+import greenlet  # type: ignore
 from typing import Any
 from typing import Callable  # type: ignore # noqa F401
 from typing import Coroutine


### PR DESCRIPTION
Add a custom rule to preserve type ignore on the imports that dont havenoqa.
https://github.com/sqlalchemy/sqlalchemy/pull/12164

related issue:
https://github.com/sqlalchemyorg/zimports/issues/5

I cant run the tests locally (on windows). Are some instructions to that?