### PR TITLE
test imports fixed

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -11,10 +11,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
       fail-fast: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
             - --black-line-length=79
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.2.0
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ be in a future release, possibly when flake8 adds toml support::
 
     [tool.black]
     line-length = 79
-    target-version = ['py37']
+    target-version = ['py39']
 
 
     [tool.zimports]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['setuptools >= 44', 'wheel']
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py39']
 exclude = './test_files'
 
 [tool.zimports]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.9
+    Programming Language : Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,12 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 project_urls =

--- a/tests.py
+++ b/tests.py
@@ -17,6 +17,10 @@ class ImportsTest(unittest.TestCase):
 
     @contextlib.contextmanager
     def _simulate_importlib(self):
+        import importlib
+
+        original_import_module = importlib.import_module
+
         def import_module(name):
             if name == "sqlalchemy":
                 return self.mock_sqlalchemy
@@ -25,7 +29,7 @@ class ImportsTest(unittest.TestCase):
             elif name == "zimports":
                 return __import__("zimports")
             else:
-                raise ImportError(name)
+                return original_import_module(name)
 
         with mock.patch(
             "zimports.zimports.importlib.import_module", import_module

--- a/tests.py
+++ b/tests.py
@@ -26,8 +26,6 @@ class ImportsTest(unittest.TestCase):
                 return self.mock_sqlalchemy
             elif name == "sqlalchemy.orm":
                 return self.mock_sqlalchemy_orm
-            elif name == "zimports":
-                return __import__("zimports")
             else:
                 return original_import_module(name)
 


### PR DESCRIPTION
Changes to allow to run tox locally, and hopefully on workflow:

- test was mocking import_module for every module, and some upstream change start to use import_module and start to get problems
- workflow was using python3.7 that is not available (remove 3.7 and 3.8 and added the new versions)
- Change flake8 version that wasn't working (at least locally against 3.12). this was the error https://github.com/PyCQA/flake8/issues/1885